### PR TITLE
Fix column order of indices.

### DIFF
--- a/pg_jts/pg_database.py
+++ b/pg_jts/pg_database.py
@@ -303,7 +303,7 @@ def get_indexes(schema_name, table_name):
     q = """
     SELECT
         index_name,
-        array_agg(attname) AS columns,
+        array_agg(attname ORDER BY column_position) AS columns,
         indisunique,
         indisprimary,
         create_statement,


### PR DESCRIPTION
Index columns are rendered in arbitrary order; fix it so they are ordered according to column position.